### PR TITLE
Add taint only if node does not already have it

### DIFF
--- a/src/reconciler/testfiles/list-nodes-eligible-and-has-taint.json
+++ b/src/reconciler/testfiles/list-nodes-eligible-and-has-taint.json
@@ -1,0 +1,66 @@
+{
+  "apiVersion": "v1",
+  "items": [
+    {
+      "apiVersion": "v1",
+      "kind": "Node",
+      "metadata": {
+        "creationTimestamp": "2024-05-07T08:32:07Z",
+        "name": "aks-artemis1-41950716-vmss000082",
+        "resourceVersion": "1906423380",
+        "uid": "52f056db-5cf3-4bcf-93f2-522b7f2f0fdc"
+      },
+      "spec": {
+        "providerID": "azure:///subscriptions/3baee020-e0a1-4297-964d-f901c9f12c87/resourceGroups/mc_rgpazewdaks01valhalla_westeurope/providers/Microsoft.Compute/virtualMachineScaleSets/aks-artemis1-41950716-vmss/virtualMachines/290",
+        "taints": [
+          {
+            "effect": "NoSchedule",
+            "key": "kubernetes.azure.com/scalesetpriority",
+            "value": "spot"
+          },
+          {
+            "effect": "NoExecute",
+            "key": "node.kubernetes.io/out-of-service",
+            "value": "spot"
+          }
+        ]
+      },
+      "status": {
+        "conditions": [
+          {
+            "lastHeartbeatTime": "2024-05-12T11:21:10Z",
+            "lastTransitionTime": "2024-05-07T08:32:09Z",
+            "message": "VM has scheduled event",
+            "reason": "VMEventScheduled",
+            "status": "True",
+            "type": "VMEventScheduled"
+          },
+          {
+            "lastHeartbeatTime": "2024-05-12T11:18:56Z",
+            "lastTransitionTime": "2024-05-07T08:32:07Z",
+            "message": "kubelet is not posting ready status",
+            "reason": "KubeletReady",
+            "status": "False",
+            "type": "Ready"
+          }
+        ],
+        "nodeInfo": {
+          "architecture": "amd64",
+          "bootID": "0db2aabd-88a7-4330-b34e-bc1af5970c63",
+          "containerRuntimeVersion": "containerd://1.7.7-1",
+          "kernelVersion": "5.15.0-1054-azure",
+          "kubeProxyVersion": "v1.28.3",
+          "kubeletVersion": "v1.28.3",
+          "machineID": "8f3ae088051c4e479604b4d18b8e204e",
+          "operatingSystem": "linux",
+          "osImage": "Ubuntu 22.04.3 LTS",
+          "systemUUID": "b82ceb75-af24-44cd-8fd3-76f3d6fa5a6b"
+        }
+      }
+    }
+  ],
+  "kind": "List",
+  "metadata": {
+    "resourceVersion": "test"
+  }
+}


### PR DESCRIPTION
This pull request updates Tainter to only add the `out-of-service` taint if a node does not already have it.